### PR TITLE
Fix crash in app.py with -c option

### DIFF
--- a/app.py
+++ b/app.py
@@ -1187,14 +1187,16 @@ if __name__ == "__main__":
     # The default configuration must be kept unchanged as it is committed to the repository, 
     # so we have to make a copy that is not comitted
     default_config = load_config("configs/config.yaml")
+    config_file_path = lollms_paths.personal_configuration_path/f"local_config.yaml"
 
     if args.config!="local_config":
-        args.config = "local_config"
-        if not lollms_paths.personal_configuration_path/f"local_config.yaml".exists():
-            print("No local configuration file found. Building from scratch")
-            shutil.copy(default_config, lollms_paths.personal_configuration_path/f"local_config.yaml")
+        print("Found local configuration file. Loading it")
+        custom_config = load_config(lollms_paths.personal_configuration_path/args.config)
+        save_config(custom_config, config_file_path)
+    else:
+        print("No local configuration file found. Building from scratch")
+        save_config(default_config, config_file_path)
 
-    config_file_path = lollms_paths.personal_configuration_path/f"local_config.yaml"
     config = LOLLMSConfig(config_file_path)
 
     


### PR DESCRIPTION
## Description
When starting `app.py` with an existing config

```
python3 app.py -c /src/gpt4all-ui/configs/custom-config.yaml
```

It crashes with:

```
Traceback (most recent call last):
  File "/src/gpt4all-ui/app.py", line 1193, in <module>
    if not lollms_paths.personal_configuration_path/f"local_config.yaml".exists():
AttributeError: 'str' object has no attribute 'exists'
```

## Type of change
Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Please put an `x` in the boxes that apply. You can also fill these out after creating the PR.

- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have tested this code locally, and it is working as intended
- [ ] I have updated the documentation accordingly

