### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ websocket-client
 GitPython
 setuptools
 numpy
+bs4


### PR DESCRIPTION
Hello, on a fresh instalation on a ubuntu 22.04.2 LTS when clicking on models zoo for download of a model there was missing dependency "bs4", so added it, now runs OK.