### PR TITLE
Fix docker not running / not preserving bindings in volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,26 @@ FROM python:3.10
 WORKDIR /srv
 COPY ./requirements.txt .
 
-RUN python3 -m venv venv && . venv/bin/activate
-RUN python3 -m pip install --no-cache-dir -r requirements.txt --upgrade pip
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./app.py /srv/app.py
 COPY ./api /srv/api
 COPY ./static /srv/static
 COPY ./templates /srv/templates
 COPY ./web /srv/web
-COPY ./configs /srv/configs
 COPY ./assets /srv/assets
 
-# COPY ./models /srv/models  # Mounting model is more efficient
-CMD ["python", "app.py", "--host", "0.0.0.0", "--port", "9600", "--db_path", "data/database.db"]
+# TODO: this is monkey-patch for check_update() function, should be disabled in Docker
+COPY ./.git /srv/.git
+
+VOLUME [ "/data" ]
+
+# Monkey-patch: send a "enter" keystroke to python to confirm the first launch process
+CMD ["/bin/bash", "-c", " \
+  echo -ne '\n' | \
+  python app.py \
+  --host 0.0.0.0 \
+  --port 9600 \
+  --db_path /data/Documents/databases/database.db \
+  --config /configs/config.yaml \
+  "]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM python:3.10
 WORKDIR /srv
 COPY ./requirements.txt .
 
-RUN pip install --no-cache-dir -r requirements.txt
-
 COPY ./app.py /srv/app.py
 COPY ./api /srv/api
 COPY ./static /srv/static
@@ -17,8 +15,12 @@ COPY ./.git /srv/.git
 
 VOLUME [ "/data" ]
 
-# Monkey-patch: send a "enter" keystroke to python to confirm the first launch process
+# Monkey-patch (1): because "binding_zoo" install the packets inside venv, we cannot do pip install on build time
+# Monkey-patch (2): send a "enter" keystroke to python to confirm the first launch process
 CMD ["/bin/bash", "-c", " \
+  python -m venv /data/venv; \
+  source /data/venv/bin/activate; \
+  python -m pip install --no-cache-dir -r requirements.txt --upgrade pip; \
   echo -ne '\n' | \
   python app.py \
   --host 0.0.0.0 \

--- a/app.py
+++ b/app.py
@@ -1998,6 +1998,8 @@ if __name__ == "__main__":
     else:
         print(f"Please open your browser and go to {url} to view the ui")
     
-    socketio.run(app, host=config["host"], port=config["port"])
+    socketio.run(app, host=config["host"], port=config["port"],
+                 # prevent error: The Werkzeug web server is not designed to run in production
+                 allow_unsafe_werkzeug=True)
     # http_server = WSGIServer((config["host"], config["port"]), app, handler_class=WebSocketHandler)
     # http_server.serve_forever()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,12 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ./data:/srv/help
-      - ./data:/srv/data
+      - ./data:/data
       - ./data/.parisneo:/root/.parisneo/
       - ./configs:/srv/configs
-      - ./web:/srv/web
+    environment:
+      - HOME=/data
+    tty: true
+    stdin_open: true
     ports: 
       - "9600:9600"


### PR DESCRIPTION
## Description

Fix the issue with Docker does not start and prints error: 

```
Traceback (most recent call last):
  File "/srv/app.py", line 1871, in <module>
    lollms_paths = LollmsPaths.find_paths(force_local=True, custom_default_cfg_path="configs/config.yaml")
  File "/usr/local/lib/python3.10/site-packages/lollms/paths.py", line 203, in find_paths
    cfg.lollms_personal_path = input(f"Folder path: ({cfg.lollms_personal_path}):")
EOFError: EOF when reading a line
```

Changes include:

- Use single mount point `/data`
- Monkey-patch to send an "enter" keystroke to the bypass the prompt for first run
- Move `venv` to runtime, not build time, because bindings seems to be install by running `pip`

Tested:

1. docker compose up
2. Download some models and bindings
3. Try chatting with the bot
4. docker compose down
5. docker compose up
6. Everything still works as expected, that means data is preserved between up & down

Maybe TODO:

- Try not to use relative `./` paths
- Maybe disable `check_update()` function, because it depends on `.git` folder that should not be copied into docker image
- Binding should use a venv provided via environment variable or argument

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Please put an `x` in the boxes that apply. You can also fill these out after creating the PR.

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested this code locally, and it is working as intended
- [ ] I have updated the documentation accordingly

## Screenshots

(None)
