### PR TITLE
Fixed a bug preventing any answer to be displayed when the personalit…

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1337,7 +1337,7 @@ class LoLLMsAPPI(LollmsApplication):
                     prompt,
                     callback=callback,
                     n_predict=n_predict,
-                    temperature=self.config['temperature'],
+                    temperature=self.config['temp'],
                     top_k=self.config['top_k'],
                     top_p=self.config['top_p'],
                     repeat_penalty=self.config['repeat_penalty'],


### PR DESCRIPTION
…y parameter are overriden: because 'temperature' is a string in the configuration and 'temp' is a float, setting temperature here fails downsteam because it attempts to parse it as a float.

## Description
This change sets the temperature in model.generate to be a float, as expected downstream. The current implementation sets it as a string, which fails later, and prevents any answer to be displayed.

Fixes # The UI hanging forever without displaying any answer in case the personality parameters are overriden

## Type of change
Bug fix (non-breaking change which fixes an issue)
