### PR TITLE
MacOS Installer Script - wrong path and command

### DIFF
--- a/scripts/macos/macos_install.sh
+++ b/scripts/macos/macos_install.sh
@@ -133,7 +133,7 @@ else
   cd ..
   cd utilities/safe_store
   pip install -e .
-  cd ../..
+  cd ../../..
 
   cd lollms-webui || exit 1
 fi
@@ -176,7 +176,6 @@ echo "Creating a bin dir (required for llamacpp binding)"
 mkdir ../installer_files/lollms_env/bin
 
 echo "Don't forget to select Apple silicon (if you are using M1, M2, M3) or apple intel (if you use old intel mac) in the settings before installing any binding"
-pause
 
 PrintBigMessage() {
   echo


### PR DESCRIPTION
Just a minimal modification to make the installer script run on a clean macos setup on first run