### PR TITLE
Update app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,9 @@ from fastapi.middleware.cors import CORSMiddleware
 import socket
 import psutil
 
+import mimetypes
+mimetypes.add_type('application/javascript', '.js')
+mimetypes.add_type('text/css', '.css')
 
 def get_ip_addresses():
     hostname = socket.gethostname()    


### PR DESCRIPTION
FIxes issue #343 in new version.

## Description
In Windows, using ollama as a backend, the UI does not load. This fixes the issue

The console shows the following error: 

`Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "text/plain". Strict MIME type checking is enforced for module scripts per HTML spec.`

Fixes # 343 that seems to have been reintroduced in a later version (humble guess)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Important:
As I am a noob contributor in this project, my code maybe is not following the style guidelines