### PR TITLE
Fix custom models not populated in DiscussionView menu

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -516,6 +516,15 @@ export const store = createStore({
           item.isInstalled=modelsArr.includes(item.name)
         })
         this.state.installedModels = this.state.modelsZoo.filter(item=> item.isInstalled)
+        const modelsNotInZoo = modelsArr.filter(modelName => !this.state.modelsZoo.some(item => item.name === modelName))
+        const installedCustomModels = modelsNotInZoo.map(modelName => ({
+          name: modelName,
+          icon: this.imgBinding,
+          isCustomModel: true,
+          isInstalled: true
+        }))
+        this.state.installedModels = [...this.state.installedModels, ...installedCustomModels]
+        commit('setInstalledModels', this.state.installedModels);
         const index = this.state.modelsZoo.findIndex(item=>item.name == this.state.config.model_name)
         if (index!=-1){
           commit('setCurrentModel',this.state.modelsZoo[index])


### PR DESCRIPTION
## Description
DiscussionView top left menu for model selection does not populate locally installed, custom models that have not been scraped from HuggingFace. 

Proposed change will select models not present in zoo, but that are detected (custom models added via reference path). Selected models will be added to installed models list, which is rendered in DiscussionView menu. 

Inspired by logic in SettingsView.vue at row 7010 to 7040. Which I believe could be optimized as well. 

Fixes #594 

## Type of change
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Please put an `x` in the boxes that apply. You can also fill these out after creating the PR.

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [/] I have tested this code locally, and it is working as intended (further test using multiple models still pending)
- [ ] I have updated the documentation accordingly

## Screenshots
If applicable, add screenshots to help explain your changes.
