### PR TITLE
fix(proxy): add auth and SSRF protection to /api/proxy (CVE-2026-33340)

### DIFF
--- a/lollms/server/endpoints/lollms_apps.py
+++ b/lollms/server/endpoints/lollms_apps.py
@@ -1,10 +1,13 @@
+import ipaddress
 import os
 import platform
 import shutil
+import socket
 import subprocess
 import sys
 import uuid
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pipmaster as pm
 import requests
@@ -435,15 +438,47 @@ async def uninstall_app(app_name: str, auth: AuthRequest):
 
 REPO_URL = "https://github.com/ParisNeo/lollms_apps_zoo.git"
 
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+]
+
+
+def _is_safe_url(url: str) -> bool:
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"}:
+            return False
+        host = parsed.hostname
+        if not host:
+            return False
+        addr = ipaddress.ip_address(socket.gethostbyname(host))
+        return not any(addr in net for net in _BLOCKED_NETWORKS)
+    except Exception:
+        return False
+
 
 class ProxyRequest(BaseModel):
+    client_id: str
     url: str
 
 
 @router.post("/api/proxy")
 async def proxy(request: ProxyRequest):
+    check_access(lollmsElfServer, request.client_id)
+    if not _is_safe_url(request.url):
+        raise HTTPException(
+            status_code=400,
+            detail="URL not allowed: must be http/https and not point to private/internal addresses",
+        )
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=False) as client:
             response = await client.get(request.url)
             return {"content": response.text}
     except Exception as e:


### PR DESCRIPTION
## Security Fix: Unauthenticated SSRF via /api/proxy

**CVE:** CVE-2026-33340
**CVSS:** 9.1 Critical
**CWE:** CWE-918 (SSRF) + CWE-306 (Missing Authentication)

### Vulnerability

The `/api/proxy` endpoint in `lollms/server/endpoints/lollms_apps.py` accepted arbitrary URLs from unauthenticated callers and fetched them server-side with no restrictions:

```python
@router.post("/api/proxy")
async def proxy(request: ProxyRequest):
    async with httpx.AsyncClient() as client:
        response = await client.get(request.url)
        return {"content": response.text}
```

An attacker could access:
- AWS/GCP/Azure instance metadata: `http://169.254.169.254/latest/meta-data/`
- Internal network services
- The lollms backend itself (`http://127.0.0.1:9601/`)

### Fix

1. **Authentication:** Added `client_id` field and `check_access()` call (matching every other protected endpoint in this file)
2. **SSRF blocklist:** Rejects requests to RFC1918, loopback, link-local, and IPv6 private ranges
3. **No redirects:** Set `follow_redirects=False` to prevent redirect-based bypass

### Testing
```bash
# Should now return 400
curl -X POST http://localhost:9600/api/proxy   -H 'Content-Type: application/json'   -d '{"client_id": "valid_id", "url": "http://169.254.169.254/"}'

# Should return 422 (missing client_id)
curl -X POST http://localhost:9600/api/proxy   -H 'Content-Type: application/json'   -d '{"url": "http://169.254.169.254/"}'
```