### PR TITLE
security: disable code execution by default in shipped config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # LoLLMs v20.0 (Next) Changelog
 Date: Mai 21, 2025  
 Moved to safestore for RAG
+- security: `turn_on_code_execution` now defaults to `false` in `configs/config.yaml` so code execution is opt-in (closes #675)
 
 # LoLLMs v19.22.42 (tWINS) Changelog
 Date: April 09, 2025  

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -23,7 +23,7 @@ show_news_panel: false
 
 # Security measures
 turn_on_setting_update_validation: true
-turn_on_code_execution: true
+turn_on_code_execution: false
 turn_on_code_validation: true
 turn_on_open_file_validation: true
 turn_on_send_file_validation: true


### PR DESCRIPTION
## Summary
- `configs/config.yaml` ships with `turn_on_code_execution: true`, which means a fresh install allows remote Python execution out of the box.
- This PR flips the default to `false` so code execution is opt-in. Users who want it can still enable it in their own config.

Follows the same secure-by-default direction as the recent `/api/proxy` hardening (#685).

Closes #675.

## Test plan
- [x] Diff is a single-line config change plus a CHANGELOG note — no code paths affected.
- [ ] Manual: start the webui with the shipped config and confirm the existing UI surface still loads (code execution features will require enabling the flag).